### PR TITLE
add Post management ViewSet with UUID lookup

### DIFF
--- a/SyntaxSphere/src/serializers.py
+++ b/SyntaxSphere/src/serializers.py
@@ -19,4 +19,24 @@ class SignInSerializer(serializers.Serializer):
 	username = serializers.CharField()
 	password = serializers.CharField()
 
+class PostSerializer(serializers.ModelSerializer):
+    class Meta:
+        model=Posts
+        fields='__all__'
+
+class LikesSerializer(serializers.ModelSerializer):
+    class Meta:
+        model=Likes
+        fields='__all__'
+
+class CommentsSerializer(serializers.ModelSerializer):
+    class Meta:
+        model=Comments
+        fields='__all__'
+
+
+
+
+
+
 

--- a/SyntaxSphere/src/urls.py
+++ b/SyntaxSphere/src/urls.py
@@ -1,9 +1,26 @@
 from django.urls import path
-from .views import SignUpView, SignInView, SignOutView
+from .views import SignUpView, SignInView, SignOutView,HandlingPostsViewSet
+from rest_framework.routers import SimpleRouter
 
+
+post_list = HandlingPostsViewSet.as_view({
+    'get': 'list',
+    'post': 'create'
+})
+
+post_detail = HandlingPostsViewSet.as_view({
+    'get': 'retrieve',
+    'delete': 'destroy'
+})
 urlpatterns = [
 	path('signup/', SignUpView.as_view(), name='signup'),
 	path('signin/', SignInView.as_view(), name='signin'),
 
-	path('signout/',SignOutView.as_view(),name='signout')
+	path('signout/',SignOutView.as_view(),name='signout'),
+	path('posts/list', post_list, name='post-list'),  # Custom URL for listing posts
+	path('posts/new', post_list, name='post-create'),  # Custom URL for creating a post
+	path('posts/<uuid:id>', post_detail, name='post-detail'),  # Custom URL for a specific post
+	path('posts/<uuid:id>', post_detail, name='post-delete'),
 ]
+
+

--- a/SyntaxSphere/src/views.py
+++ b/SyntaxSphere/src/views.py
@@ -2,10 +2,10 @@ from django.contrib.auth import authenticate
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.response import Response
 from rest_framework import status
-from rest_framework import generics
+from rest_framework import generics,viewsets,filters
 from rest_framework.permissions import AllowAny, IsAuthenticated
-from .models import User
-from .serializers import UserSerializer, SignInSerializer
+from .models import User, Posts
+from .serializers import UserSerializer, SignInSerializer, PostSerializer
 
 
 class SignUpView(generics.CreateAPIView):
@@ -49,9 +49,18 @@ class SignOutView(generics.CreateAPIView):
 
 	def post(self, request):
 		try:
-			refresh_token=request.data['refresh']
-			token=RefreshToken(refresh_token)
+			refresh_token = request.data['refresh']
+			token = RefreshToken(refresh_token)
 			token.blacklist()
 			return Response(status=status.HTTP_205_RESET_CONTENT)
 		except AttributeError:
 			return Response(status=status.HTTP_400_BAD_REQUEST)
+
+class HandlingPostsViewSet(viewsets.ModelViewSet):
+	permission_classes = (IsAuthenticated,)
+
+	queryset = Posts.objects.all()
+	serializer_class = PostSerializer
+	filter_backends = [filters.SearchFilter]
+	search_fields = ['title']
+	lookup_field='id'


### PR DESCRIPTION
#5 post mgmt
- Implemented HandlingPostsViewSet for managing posts.
- Configured viewset to use UUID as the lookup field instead of the default pk.
- Updated URLs to support UUID-based retrieval for post detail view.